### PR TITLE
[CallerMemberName]

### DIFF
--- a/KinectMvvm/Framework/ViewModel.cs
+++ b/KinectMvvm/Framework/ViewModel.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.UI.Xaml.Navigation;
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace KinectMvvm.Framework
 {
@@ -12,7 +7,7 @@ namespace KinectMvvm.Framework
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public void RaisePropertyChanged(string propName)
+        protected void RaisePropertyChanged([CallerMemberName] string propName = null)
         {
             if (PropertyChanged != null)
             {
@@ -22,12 +17,10 @@ namespace KinectMvvm.Framework
 
         public virtual void OnNavigatedFrom()
         {
-
         }
 
         public virtual void OnNavigatedTo()
         {
-
-        }    
+        }
     }
 }

--- a/KinectMvvm/Head/HeadViewModel.cs
+++ b/KinectMvvm/Head/HeadViewModel.cs
@@ -16,7 +16,7 @@ namespace KinectMvvm.Head
             set
             {
                 this.x = value;
-                RaisePropertyChanged("X");
+                RaisePropertyChanged();
             }
         }
 
@@ -31,7 +31,7 @@ namespace KinectMvvm.Head
             set
             {
                 this.y = value;
-                RaisePropertyChanged("Y");
+                RaisePropertyChanged();
             }
         }
 
@@ -46,7 +46,7 @@ namespace KinectMvvm.Head
             set
             {
                 this.z = value;
-                RaisePropertyChanged("Z");
+                RaisePropertyChanged();
             }
         }
 

--- a/KinectMvvm/Main/MainViewModel.cs
+++ b/KinectMvvm/Main/MainViewModel.cs
@@ -88,7 +88,7 @@ namespace KinectMvvm.Main
             set
             {
                 this.infraredData = value;
-                RaisePropertyChanged("InfraredData");
+                RaisePropertyChanged();
             }
         }
 
@@ -103,7 +103,7 @@ namespace KinectMvvm.Main
             set
             {
                 this.colourData = value;
-                RaisePropertyChanged("ColourData");
+                RaisePropertyChanged();
             }
         }
 


### PR DESCRIPTION
Thanks to `CallerMemberNameAttribute` you don't need to use a string to identify the changing property.
